### PR TITLE
Unshared play

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -1,6 +1,7 @@
 # Planetary Annihilation TITANS: `ui` + `server-script` Folder Guide
 
 This guide explains what the subfolders generally do, based on reading representative files in each area.
+Additionally, it contains notes for human and AI developers.
 
 ## Scope and approach
 - Focused on:
@@ -133,3 +134,127 @@ Bundled third-party libraries.
 - This is a general architectural guide, not a strict API contract.
 - File names and patterns are stable enough to use as navigation heuristics for new contributors or AI tools.
 - When making new changes, ensure that the python script `generate_mod.py` is up to date with all files touched.
+- Agents should not run `generate_mod.py`.
+- When writing code, do not try to silently succeed and ignore non-critical errors. Consider the following block of code:
+```javascript
+    var normalizeHumanArmiesForSharedControl = function(config, connectedClients) {
+        if (!config || !_.isArray(config.armies))
+            return;
+
+        var humanTemplate;
+        _.forEach(config.armies, function(army) {
+            if (!humanTemplate && !armyHasAI(army))
+                humanTemplate = army;
+        });
+
+        if (!humanTemplate)
+            return;
+
+        var baseSlot = _.find(humanTemplate.slots || [], function(slot) {
+            return slot && !slot.ai;
+        }) || { name: 'Player' };
+        var playerCount = Math.max(1, connectedClients.length);
+        var inserted = false;
+        var splitArmies = _.map(_.range(0, playerCount), function(index) {
+            var slot = _.clone(baseSlot);
+            delete slot.client;
+            delete slot.ai;
+
+            return {
+                slots: [slot],
+                color: getColorPairForPlayerArmy(index, humanTemplate.color),
+                econ_rate: _.has(humanTemplate, 'econ_rate') ? humanTemplate.econ_rate : 1,
+                spec_tag: humanTemplate.spec_tag || '.player',
+                alliance_group: humanTemplate.alliance_group || 1
+            };
+        });
+
+        config.armies = _.reduce(config.armies, function(result, army) {
+            if (!armyHasAI(army)) {
+                if (!inserted) {
+                    result = result.concat(splitArmies);
+                    inserted = true;
+                }
+                return result;
+            }
+
+            result.push(army);
+            return result;
+        }, []);
+
+        console.log('[GW COOP] - unshared control enabled; split humans into ' + splitArmies.length + ' allied armies');
+    };
+```
+- When written this way, the code works, but it silently bypasses a couple of failures in an effort to guarantee that it doesn't crash. Consider the case when `connectedClients` is null. This code will not fail, and instead generate a single army when multiple should have been generated. The source of this strange generate would be harder to track down than if the code had just crashed and printed a message to the log. Similar problems also exist in this snippet, like with `baseSlot` defaulting to `{ name: 'Player' }` if no human slot can be found in what should be a human army. Moreover, this code fails to take into account PA specific knowledge, like how a human army will never have AI slots in it as AIs cannot share armies with human players. A better version of this same code is given below:
+```javascript
+    var normalizeHumanArmiesForSharedControl = function(config, connectedClients) {
+        if (!config || !_.isArray(config.armies)) {
+            return;
+        }
+
+        if (!connectedClients || !_.isArray(connectedClients) || connectedClients.length === 0) {
+            console.log('[GW COOP] No connected clients found.');
+            return;
+        }
+
+        var humanArmyCount = 0;
+
+        // Figure out which army is the one in normal GW that would be marked
+        // as the human player (so we can then use it as a template to create more armies).
+        var humanTemplate;
+        _.forEach(config.armies, function(army) {
+            if (!armyHasAI(army)) {
+                humanTemplate = army;
+                humanArmyCount++;
+            }
+        });
+
+        if (humanArmyCount !== 1) {
+            console.log('[GW COOP] Expected exactly one human army, found ' + humanArmyCount + '.');
+            return;
+        }
+
+        if (!humanTemplate) {
+            console.log('[GW COOP] No human player template found.');
+            return;
+        }
+
+        var baseSlot = humanTemplate.slots && humanTemplate.slots[0];
+
+        if (!baseSlot) {
+            console.log('[GW COOP] No valid base slot found.');
+            return;
+        }
+
+        // Create a new army for each connected client.
+        var splitArmies = _.map(_.range(0, connectedClients.length), function(index) {
+            var slot = _.cloneDeep(baseSlot);
+            // Slots will be assigned to specific clients later in startGame().
+            delete slot.client;
+            delete slot.ai;
+            delete slot.name;
+
+            return {
+                slots: [slot],
+                // I assume here that humanTemplate.color is both a valid color and the main faction color.
+                color: getColorPairForPlayerArmy(index, humanTemplate.color),
+                econ_rate: _.has(humanTemplate, 'econ_rate') ? humanTemplate.econ_rate : 1,
+                spec_tag: humanTemplate.spec_tag || '.player',
+                alliance_group: humanTemplate.alliance_group
+            };
+        });
+
+        config.armies = _.reduce(config.armies, function(result, army) {
+            if (!armyHasAI(army)) {
+                return result.concat(splitArmies);
+            }
+
+            result.push(army);
+            return result;
+        }, []);
+
+        console.log('[GW COOP] - unshared control enabled; split humans into ' + splitArmies.length + ' allied armies');
+    };
+```
+- In general, the idea of the new version of the code is that crashing with an informative log message is preferable to succeeding in a mysterious way, as such successes can lead to mysterious and difficult to debug issues.
+- Related to this, if you are using an LLM, do not "vibecode". LLMs can be used to assist and enhance the development process, but any code generated should be very carefully reviewed before use (honestly the exact same thing is true for human written code. Code in general should be reviewed carefully). It is the responsibility of the developer using the LLM to ensure that the generated code is correct and follows best practices.

--- a/server-script/states/game_over.js
+++ b/server-script/states/game_over.js
@@ -149,7 +149,7 @@ function beginGwCampaignProcessRestart() {
             return client.id;
         });
 
-        console.log('[GW_COOP] sending restart_prepare to connected clients=' + JSON.stringify(recipients));
+        console.log('[GW COOP] sending restart_prepare to connected clients=' + JSON.stringify(recipients));
 
         server.broadcast({
             message_type: 'gw_return_to_campaign_restart_prepare',
@@ -182,7 +182,7 @@ function beginGwCampaignProcessRestart() {
     // Now we delay the process shutdown to give clients enough time to receive the restart message and 
     // switch into reconnect mode before we kill the server. 
     _.delay(function() {
-        console.log('[GW_COOP] Executing process-level restart from game_over after delay=' + GW_CAMPAIGN_RESTART_BROADCAST_DELAY_MS + 'ms');
+        console.log('[GW COOP] Executing process-level restart from game_over after delay=' + GW_CAMPAIGN_RESTART_BROADCAST_DELAY_MS + 'ms');
         // Ensure process exits after sim shutdown so clients can reconnect to a
         // newly-started campaign server instead of reusing this ended battle process.
         sim.onShutdown = server.exit;
@@ -253,7 +253,7 @@ exports.enter = function (game_over_data)
         if (gwCampaignRestartRequested || !isGwCampaignCoopMatch())
             return;
 
-        console.log('[GW_COOP] game_over host disconnect shutdown reason=' + reason);
+        console.log('[GW COOP] game_over host disconnect shutdown reason=' + reason);
         writeReplay();
         sim.onShutdown = server.exit;
         sim.shutdown(true);

--- a/server-script/states/gw_campaign.js
+++ b/server-script/states/gw_campaign.js
@@ -163,7 +163,7 @@ function GWCampaignModel(creator) {
         if (!_.isEqual(previousRequiredIdentifiers, self.requiredClientModIdentifiers))
             self.clientManifestValidatedByClientId = {};
 
-        console.log('[GW_COOP] MOD CHECK [gw_campaign] required_identifiers=' + JSON.stringify(self.requiredClientModIdentifiers));
+        console.log('[GW COOP] MOD CHECK [gw_campaign] required_identifiers=' + JSON.stringify(self.requiredClientModIdentifiers));
 
         if (!self.requiredClientModIdentifiers.length)
             self.clearAllPendingManifestTimeouts();
@@ -226,7 +226,7 @@ function GWCampaignModel(creator) {
 
         self.clearPendingSelfDisconnectTimeout(client.id);
 
-        console.log('[GW_COOP] MOD CHECK [gw_campaign] notifying client=' + client.id + ' missing=' + JSON.stringify(missingIdentifiers) + ' reason="' + rejectReason + '"');
+        console.log('[GW COOP] MOD CHECK [gw_campaign] notifying client=' + client.id + ' missing=' + JSON.stringify(missingIdentifiers) + ' reason="' + rejectReason + '"');
 
         client.message({
             message_type: 'required_client_mods_missing',
@@ -243,25 +243,25 @@ function GWCampaignModel(creator) {
                 return;
 
             self.clearPendingSelfDisconnectTimeout(client.id);
-            console.warn('[GW_COOP] MOD CHECK [gw_campaign] client did not self-disconnect after missing required mod notice; leaving connection open client=' + client.id + ' reason="' + rejectReason + '"');
+            console.warn('[GW COOP] MOD CHECK [gw_campaign] client did not self-disconnect after missing required mod notice; leaving connection open client=' + client.id + ' reason="' + rejectReason + '"');
         }, CLIENT_MOD_SELF_DISCONNECT_TIMEOUT_MS);
     };
 
     self.requestClientManifest = function(client, reconnect) {
         if (!client || !client.connected) {
-            console.log('[GW_COOP] MOD CHECK [gw_campaign] skipping manifest request for invalid/disconnected client');
+            console.log('[GW COOP] MOD CHECK [gw_campaign] skipping manifest request for invalid/disconnected client');
             return;
         }
 
         if (!self.requiredClientModIdentifiers.length) {
-            console.log('[GW_COOP] MOD CHECK [gw_campaign] no required client mods set; allowing client=' + client.id + ' without manifest gate');
+            console.log('[GW COOP] MOD CHECK [gw_campaign] no required client mods set; allowing client=' + client.id + ' without manifest gate');
             return;
         }
 
         self.clearPendingManifestTimeout(client.id);
         self.clientManifestReceivedByClientId[client.id] = false;
 
-        console.log('[GW_COOP] MOD CHECK [gw_campaign] requesting manifest from client=' + client.id + ' reconnect=' + !!reconnect + ' required=' + JSON.stringify(self.requiredClientModIdentifiers));
+        console.log('[GW COOP] MOD CHECK [gw_campaign] requesting manifest from client=' + client.id + ' reconnect=' + !!reconnect + ' required=' + JSON.stringify(self.requiredClientModIdentifiers));
 
         client.message({
             message_type: 'request_client_mod_manifest',
@@ -277,7 +277,7 @@ function GWCampaignModel(creator) {
 
             self.clearPendingManifestTimeout(client.id);
             self.clientManifestValidatedByClientId[client.id] = false;
-            console.warn('[GW_COOP] MOD CHECK [gw_campaign] manifest timeout; leaving connection open client=' + client.id + ' reason="' + self.buildMissingRequiredModsReason() + '"');
+            console.warn('[GW COOP] MOD CHECK [gw_campaign] manifest timeout; leaving connection open client=' + client.id + ' reason="' + self.buildMissingRequiredModsReason() + '"');
         }, CLIENT_MOD_MANIFEST_TIMEOUT_MS);
     };
 
@@ -455,7 +455,7 @@ function GWCampaignModel(creator) {
             return;
 
         var role = self.getRoleForClient(client);
-        console.log('[GW_COOP] gw_campaign sendRole client=' + client.name + ' id=' + client.id + ' role=' + role);
+        console.log('[GW COOP] gw_campaign sendRole client=' + client.name + ' id=' + client.id + ' role=' + role);
 
         client.message({
             message_type: 'gw_campaign_role',
@@ -483,7 +483,7 @@ function GWCampaignModel(creator) {
             // that gets sent to the UI, since the host client object can sometimes be in a weird state where 
             // it's not showing up as connected in server.clients even though the host is definitely connected 
             // and should be included in the list of clients that gets sent to the UI.
-            console.log('[GW_COOP] gw_campaign updateControl client=' + client.name + ' id=' + client.id + ' connected=' + client.connected);
+            console.log('[GW COOP] gw_campaign updateControl client=' + client.name + ' id=' + client.id + ' connected=' + client.connected);
             return {
                 id: client.id,
                 name: client.name || (client.id === self.creatorId ? self.creatorName : 'Player'),
@@ -502,7 +502,7 @@ function GWCampaignModel(creator) {
         self.control.require_password = !!bouncer.doesGameRequirePassword();
 
         self.updateBeacon();
-        console.log('[GW_COOP] gw_campaign updateControl clients=' + connectedClients.length + ' seq=' + self.lastSnapshotSeq + ' hasSnapshot=' + (!!self.lastSnapshot));
+        console.log('[GW COOP] gw_campaign updateControl clients=' + connectedClients.length + ' seq=' + self.lastSnapshotSeq + ' hasSnapshot=' + (!!self.lastSnapshot));
         self.broadcastControl();
 
         // Role messages can be missed during panel transitions; resend on every control update.
@@ -633,13 +633,13 @@ function GWCampaignModel(creator) {
             client._gwCampaignDisconnectAttached = true;
             client._gwCampaignDisconnectCleanupApplied = false;
             utils.pushCallback(client, 'onDisconnect', function(onDisconnect) {
-                console.log('[GW_COOP] gw_campaign onDisconnect client=' + client.name + ' id=' + client.id);
+                console.log('[GW COOP] gw_campaign onDisconnect client=' + client.name + ' id=' + client.id);
                 self.clearPendingManifestTimeout(client.id);
                 self.clearPendingSelfDisconnectTimeout(client.id);
                 delete self.clientLoading[client.id];
 
                 if (client.id === self.creatorId) {
-                    console.log('[GW_COOP] gw_campaign creator disconnected, exiting server');
+                    console.log('[GW COOP] gw_campaign creator disconnected, exiting server');
                     server.exit();
                 }
                 else {
@@ -688,7 +688,7 @@ function GWCampaignModel(creator) {
     self.enter = function() {
         self.active = true;
         server.maxClients = self.maxClients;
-        console.log('[GW_COOP] gw_campaign enter host=' + self.creatorName + ' id=' + self.creatorId);
+        console.log('[GW COOP] gw_campaign enter host=' + self.creatorName + ' id=' + self.creatorId);
 
         // No password by default, but clear any that might be lingering from previous sessions just in case, along with whitelist/blacklist
         // (which would correspond to the friends list unless there's some system I've never heard of before which also sets up
@@ -705,7 +705,7 @@ function GWCampaignModel(creator) {
                     return server.respond(msg).fail('Required client mods can only be provided by host');
 
                 var payload = msg.payload || {};
-                console.log('[GW_COOP] MOD CHECK [gw_campaign] host set_required_client_mods from=' + msg.client.id + ' payload=' + JSON.stringify(payload));
+                console.log('[GW COOP] MOD CHECK [gw_campaign] host set_required_client_mods from=' + msg.client.id + ' payload=' + JSON.stringify(payload));
                 self.setRequiredClientModsData(payload.required_identifiers, payload.required_names_by_id);
                 server.respond(msg).succeed({
                     required_identifiers: self.requiredClientModIdentifiers
@@ -713,7 +713,7 @@ function GWCampaignModel(creator) {
             },
             client_mod_manifest: function(msg) {
                 if (!self.requiredClientModIdentifiers.length) {
-                    console.log('[GW_COOP] MOD CHECK [gw_campaign] received manifest from client=' + msg.client.id + ' but no required list is active');
+                    console.log('[GW COOP] MOD CHECK [gw_campaign] received manifest from client=' + msg.client.id + ' but no required list is active');
                     return server.respond(msg).succeed({ missing: [] });
                 }
 
@@ -722,7 +722,7 @@ function GWCampaignModel(creator) {
                     return activeIdentifiers.indexOf(identifier) === -1;
                 });
 
-                console.log('[GW_COOP] MOD CHECK [gw_campaign] manifest from client=' + msg.client.id
+                console.log('[GW COOP] MOD CHECK [gw_campaign] manifest from client=' + msg.client.id
                     + ' active=' + JSON.stringify(activeIdentifiers)
                     + ' missing=' + JSON.stringify(missingIdentifiers)
                     + ' required=' + JSON.stringify(self.requiredClientModIdentifiers));
@@ -748,7 +748,7 @@ function GWCampaignModel(creator) {
                 server.respond(msg).succeed({ missing: [] });
 
                 if (msg.client && msg.client.connected) {
-                    console.log('[GW_COOP] MOD CHECK [gw_campaign] all_client_mods_match client=' + msg.client.id);
+                    console.log('[GW COOP] MOD CHECK [gw_campaign] all_client_mods_match client=' + msg.client.id);
                     msg.client.message({
                         message_type: 'all_client_mods_match',
                         payload: {
@@ -759,11 +759,11 @@ function GWCampaignModel(creator) {
             },
             required_client_mods_acknowledged: function(msg) {
                 self.clearPendingSelfDisconnectTimeout(msg.client.id);
-                console.log('[GW_COOP] MOD CHECK [gw_campaign] client acknowledged missing required mods client=' + msg.client.id + ' payload=' + JSON.stringify(msg.payload || {}));
+                console.log('[GW COOP] MOD CHECK [gw_campaign] client acknowledged missing required mods client=' + msg.client.id + ' payload=' + JSON.stringify(msg.payload || {}));
                 server.respond(msg).succeed();
             },
             request_gw_campaign_snapshot: function(msg) {
-                console.log('[GW_COOP] request_gw_campaign_snapshot from=' + msg.client.name + ' id=' + msg.client.id);
+                console.log('[GW COOP] request_gw_campaign_snapshot from=' + msg.client.name + ' id=' + msg.client.id);
                 var freshSnapshotRequested = false;
                 var viewerRequest = msg.client.id !== self.creatorId;
 
@@ -792,7 +792,7 @@ function GWCampaignModel(creator) {
                 };
 
                 self.updateControl();
-                console.log('[GW_COOP] gw_campaign_snapshot accepted seq=' + self.lastSnapshotSeq + ' from host');
+                console.log('[GW COOP] gw_campaign_snapshot accepted seq=' + self.lastSnapshotSeq + ' from host');
 
                 // Relay to every connected peer except host.
                 _.forEach(self.getConnectedClients(), function(client) {
@@ -807,7 +807,7 @@ function GWCampaignModel(creator) {
                     return server.respond(msg).fail('Only host can publish campaign actions');
 
                 var payload = msg.payload || {};
-                console.log('[GW_COOP] gw_campaign_action type=' + payload.type + ' from host=' + msg.client.name);
+                console.log('[GW COOP] gw_campaign_action type=' + payload.type + ' from host=' + msg.client.name);
 
                 _.forEach(self.getConnectedClients(), function(client) {
                     if (client.id === self.creatorId)
@@ -825,12 +825,12 @@ function GWCampaignModel(creator) {
                 if (msg.client.id !== self.creatorId)
                     return server.respond(msg).fail('Only host can launch battle');
 
-                console.log('[GW_COOP] launch_gw_battle by host=' + msg.client.name);
+                console.log('[GW COOP] launch_gw_battle by host=' + msg.client.name);
                 server.respond(msg).succeed();
                 main.setState(main.states.gw_lobby, msg.client, self.buildGwLobbyLaunchContext(msg.payload));
             },
             leave_gw_campaign: function(msg) {
-                console.log('[GW_COOP] leave_gw_campaign from=' + msg.client.name + ' id=' + msg.client.id);
+                console.log('[GW COOP] leave_gw_campaign from=' + msg.client.name + ' id=' + msg.client.id);
 
                 if (msg.client.id === self.creatorId) {
                     server.respond(msg).succeed();
@@ -933,9 +933,9 @@ function GWCampaignModel(creator) {
             if (!self.active)
                 return onConnect;
 
-            console.log('[GW_COOP] gw_campaign onConnect client=' + client.name + ' id=' + client.id + ' reconnect=' + !!reconnect);
+            console.log('[GW COOP] gw_campaign onConnect client=' + client.name + ' id=' + client.id + ' reconnect=' + !!reconnect);
             if (!self.hasRoomForClient(client, reconnect)) {
-                console.log('[GW_COOP] gw_campaign rejecting client=' + client.name + ' id=' + client.id + ' reason=No room');
+                console.log('[GW COOP] gw_campaign rejecting client=' + client.name + ' id=' + client.id + ' reason=No room');
                 server.rejectClient(client, 'No room');
                 return onConnect;
             }
@@ -946,7 +946,7 @@ function GWCampaignModel(creator) {
 
         // The host is already connected when entering from empty state.
         _.forEach(self.getConnectedClients(), function(client) {
-            console.log('[GW_COOP] gw_campaign attach existing client=' + client.name + ' id=' + client.id);
+            console.log('[GW COOP] gw_campaign attach existing client=' + client.name + ' id=' + client.id);
             self.attachClientLifecycle(client, false);
         });
 
@@ -954,7 +954,7 @@ function GWCampaignModel(creator) {
     };
 
     self.exit = function() {
-        console.log('[GW_COOP] gw_campaign exit');
+        console.log('[GW COOP] gw_campaign exit');
 
         // Mark the state as inactive so that any late-arriving connections or messages that somehow slip through the cracks
         // don't get sent through gw_campaign handlers that might still be hanging around.

--- a/server-script/states/gw_campaign.js
+++ b/server-script/states/gw_campaign.js
@@ -34,6 +34,7 @@ function GWCampaignModel(creator) {
     self.maxClientsLimit = self.baseMaxClientsLimit;
     self.maxClientsLocked = false;
     self.maxClients = Math.max(1, Math.min(DEFAULT_GW_CAMPAIGN_PLAYERS, self.maxClientsLimit));
+    self.sharedControl = true;
 
     self.creatorId = creator.id;
     self.creatorName = creator.name;
@@ -77,6 +78,7 @@ function GWCampaignModel(creator) {
         max_clients: self.maxClients,
         max_clients_limit: self.maxClientsLimit,
         max_clients_locked: self.maxClientsLocked,
+        shared_control: self.sharedControl,
         connected_clients: [],
         has_snapshot: false,
         snapshot_seq: 0,
@@ -291,7 +293,8 @@ function GWCampaignModel(creator) {
             tag: _.isString(self.settings.tag) ? self.settings.tag : 'Testing',
             public: _.isBoolean(self.settings.public) ? self.settings.public : true,
             friends: !!self.settings.friends,
-            hidden: !!self.settings.hidden
+            hidden: !!self.settings.hidden,
+            shared_control: self.sharedControl
         };
 
         // Host payload is optional fallback metadata; authoritative values come from self.settings.
@@ -305,6 +308,7 @@ function GWCampaignModel(creator) {
             current_star: _.isNumber(data.current_star) ? data.current_star : undefined,
             settings: settings,
             max_clients: self.maxClients,
+            shared_control: self.sharedControl,
             required_client_mods: {
                 required_identifiers: _.clone(self.requiredClientModIdentifiers),
                 required_names_by_id: _.cloneDeep(self.requiredClientModNamesById)
@@ -333,6 +337,9 @@ function GWCampaignModel(creator) {
 
         if (_.isBoolean(data.public))
             self.settings.public = data.public;
+
+        if (_.has(data, 'shared_control'))
+            self.sharedControl = !!data.shared_control;
 
         if (_.has(data, 'max_clients_locked')) {
             self.maxClientsLocked = !!data.max_clients_locked;
@@ -488,6 +495,7 @@ function GWCampaignModel(creator) {
         self.control.max_clients = self.maxClients;
         self.control.max_clients_limit = self.maxClientsLimit;
         self.control.max_clients_locked = self.maxClientsLocked;
+        self.control.shared_control = self.sharedControl;
         self.control.has_snapshot = !!self.lastSnapshot;
         self.control.snapshot_seq = self.lastSnapshotSeq;
         self.control.settings = _.cloneDeep(self.settings);
@@ -876,7 +884,8 @@ function GWCampaignModel(creator) {
                     settings: _.cloneDeep(self.settings),
                     max_clients: self.maxClients,
                     max_clients_limit: self.maxClientsLimit,
-                    max_clients_locked: self.maxClientsLocked
+                    max_clients_locked: self.maxClientsLocked,
+                    shared_control: self.sharedControl
                 });
             },
             // Handler for chat messages sent by clients in the lobby. 

--- a/server-script/states/gw_lobby.js
+++ b/server-script/states/gw_lobby.js
@@ -146,7 +146,7 @@ function LobbyModel(creator, launchContext) {
 
     self.setRequiredClientModsData = function(requiredIdentifiers, requiredNamesById) {
         if (!self.campaignActive) {
-            console.log('[GW_COOP] MOD CHECK [gw_lobby] campaign inactive; clearing required client mod list');
+            console.log('[GW COOP] MOD CHECK [gw_lobby] campaign inactive; clearing required client mod list');
             self.requiredClientModIdentifiers = [];
             self.requiredClientModNamesById = {};
             self.clientManifestValidatedByClientId = {};
@@ -161,7 +161,7 @@ function LobbyModel(creator, launchContext) {
         if (!_.isEqual(previousRequiredIdentifiers, self.requiredClientModIdentifiers))
             self.clientManifestValidatedByClientId = {};
 
-        console.log('[GW_COOP] MOD CHECK [gw_lobby] required_identifiers=' + JSON.stringify(self.requiredClientModIdentifiers));
+        console.log('[GW COOP] MOD CHECK [gw_lobby] required_identifiers=' + JSON.stringify(self.requiredClientModIdentifiers));
 
         if (!self.requiredClientModIdentifiers.length)
             self.clearAllPendingManifestTimeouts();
@@ -224,7 +224,7 @@ function LobbyModel(creator, launchContext) {
 
         self.clearPendingSelfDisconnectTimeout(client.id);
 
-        console.log('[GW_COOP] MOD CHECK [gw_lobby] notifying client=' + client.id + ' missing=' + JSON.stringify(missingIdentifiers) + ' reason="' + rejectReason + '"');
+        console.log('[GW COOP] MOD CHECK [gw_lobby] notifying client=' + client.id + ' missing=' + JSON.stringify(missingIdentifiers) + ' reason="' + rejectReason + '"');
 
         client.message({
             message_type: 'required_client_mods_missing',
@@ -241,30 +241,30 @@ function LobbyModel(creator, launchContext) {
                 return;
 
             self.clearPendingSelfDisconnectTimeout(client.id);
-            console.warn('[GW_COOP] MOD CHECK [gw_lobby] client did not self-disconnect after missing required mod notice; leaving connection open client=' + client.id + ' reason="' + rejectReason + '"');
+            console.warn('[GW COOP] MOD CHECK [gw_lobby] client did not self-disconnect after missing required mod notice; leaving connection open client=' + client.id + ' reason="' + rejectReason + '"');
         }, CLIENT_MOD_SELF_DISCONNECT_TIMEOUT_MS);
     };
 
     self.requestClientManifest = function(client, reconnect) {
         if (self.isSingleplayerGW) {
-            console.log('[GW_COOP] MOD CHECK [gw_lobby] singleplayer GW; skipping manifest request');
+            console.log('[GW COOP] MOD CHECK [gw_lobby] singleplayer GW; skipping manifest request');
             return;
         }
 
         if (!client || !client.connected) {
-            console.log('[GW_COOP] MOD CHECK [gw_lobby] skipping manifest request for invalid/disconnected client');
+            console.log('[GW COOP] MOD CHECK [gw_lobby] skipping manifest request for invalid/disconnected client');
             return;
         }
 
         if (!self.requiredClientModIdentifiers.length) {
-            console.log('[GW_COOP] MOD CHECK [gw_lobby] no required list set; allowing client=' + client.id + ' without manifest gate');
+            console.log('[GW COOP] MOD CHECK [gw_lobby] no required list set; allowing client=' + client.id + ' without manifest gate');
             return;
         }
 
         self.clearPendingManifestTimeout(client.id);
         self.clientManifestReceivedByClientId[client.id] = false;
 
-        console.log('[GW_COOP] MOD CHECK [gw_lobby] requesting manifest from client=' + client.id + ' reconnect=' + !!reconnect + ' required=' + JSON.stringify(self.requiredClientModIdentifiers));
+        console.log('[GW COOP] MOD CHECK [gw_lobby] requesting manifest from client=' + client.id + ' reconnect=' + !!reconnect + ' required=' + JSON.stringify(self.requiredClientModIdentifiers));
 
         client.message({
             message_type: 'request_client_mod_manifest',
@@ -280,7 +280,7 @@ function LobbyModel(creator, launchContext) {
 
             self.clearPendingManifestTimeout(client.id);
             self.clientManifestValidatedByClientId[client.id] = false;
-            console.warn('[GW_COOP] MOD CHECK [gw_lobby] manifest timeout; leaving connection open client=' + client.id + ' reason="' + self.buildMissingRequiredModsReason() + '"');
+            console.warn('[GW COOP] MOD CHECK [gw_lobby] manifest timeout; leaving connection open client=' + client.id + ' reason="' + self.buildMissingRequiredModsReason() + '"');
         }, CLIENT_MOD_MANIFEST_TIMEOUT_MS);
     };
 
@@ -852,7 +852,7 @@ function LobbyModel(creator, launchContext) {
                 return response.fail('Invalid message');
 
             var payload = msg.payload || {};
-            console.log('[GW_COOP] MOD CHECK [gw_lobby] host set_required_client_mods from=' + msg.client.id + ' payload=' + JSON.stringify(payload));
+            console.log('[GW COOP] MOD CHECK [gw_lobby] host set_required_client_mods from=' + msg.client.id + ' payload=' + JSON.stringify(payload));
             self.setRequiredClientModsData(payload.required_identifiers, payload.required_names_by_id);
             response.succeed({
                 required_identifiers: self.requiredClientModIdentifiers
@@ -860,7 +860,7 @@ function LobbyModel(creator, launchContext) {
         },
         client_mod_manifest: function(msg, response) {
             if (!self.requiredClientModIdentifiers.length) {
-                console.log('[GW_COOP] MOD CHECK [gw_lobby] received manifest from client=' + msg.client.id + ' but no required list is active');
+                console.log('[GW COOP] MOD CHECK [gw_lobby] received manifest from client=' + msg.client.id + ' but no required list is active');
                 return response.succeed({ missing: [] });
             }
 
@@ -869,7 +869,7 @@ function LobbyModel(creator, launchContext) {
                 return activeIdentifiers.indexOf(identifier) === -1;
             });
 
-            console.log('[GW_COOP] MOD CHECK [gw_lobby] manifest from client=' + msg.client.id
+            console.log('[GW COOP] MOD CHECK [gw_lobby] manifest from client=' + msg.client.id
                 + ' active=' + JSON.stringify(activeIdentifiers)
                 + ' missing=' + JSON.stringify(missingIdentifiers)
                 + ' required=' + JSON.stringify(self.requiredClientModIdentifiers));
@@ -895,7 +895,7 @@ function LobbyModel(creator, launchContext) {
             response.succeed({ missing: [] });
 
             if (msg.client && msg.client.connected) {
-                console.log('[GW_COOP] MOD CHECK [gw_lobby] all_client_mods_match client=' + msg.client.id);
+                console.log('[GW COOP] MOD CHECK [gw_lobby] all_client_mods_match client=' + msg.client.id);
                 msg.client.message({
                     message_type: 'all_client_mods_match',
                     payload: {
@@ -906,7 +906,7 @@ function LobbyModel(creator, launchContext) {
         },
         required_client_mods_acknowledged: function(msg, response) {
             self.clearPendingSelfDisconnectTimeout(msg.client.id);
-            console.log('[GW_COOP] MOD CHECK [gw_lobby] client acknowledged missing required mods client=' + msg.client.id + ' payload=' + JSON.stringify(msg.payload || {}));
+            console.log('[GW COOP] MOD CHECK [gw_lobby] client acknowledged missing required mods client=' + msg.client.id + ' payload=' + JSON.stringify(msg.payload || {}));
             response.succeed();
         }
     };

--- a/server-script/states/gw_lobby.js
+++ b/server-script/states/gw_lobby.js
@@ -26,6 +26,12 @@ var getGWMaxPlayers = function() {
 };
 var MAX_GW_PLAYERS = getGWMaxPlayers();
 
+// Controls the range of color variation for player in unshared coop sessions.
+// Each of the R, G, and B color channels can vary from the host's color 
+// (determined by which faction the player belongs to) by at most PLAYER_COLOR_VARIATION_RANGE
+// in either the positive or negative direction.
+var PLAYER_COLOR_VARIATION_RANGE = 35;
+
 var debugging = false;
 
 function debug_log(object) {
@@ -376,7 +382,7 @@ function LobbyModel(creator, launchContext) {
             self.changeControl({ starting: false });
 
         if (!!self.creatorReady() && !allConfigReady)
-            console.log('GW - Waiting for all clients to mount GW config before start');
+            console.log('[GW COOP] Waiting for all clients to mount GW config before start');
     };
 
     self.updateBeacon = function() {
@@ -474,6 +480,107 @@ function LobbyModel(creator, launchContext) {
         });
     };
 
+    // In the following code, a color is essentially a type of array containing three integers
+    // (R, G, B) which must be in the range 0-255.
+
+    var clampColorChannel = function(value) {
+        return Math.max(0, Math.min(255, Math.round(value)));
+    };
+
+    var randomizeColorNearFactionColor = function(color) {
+        // For every item in the color array, we map it to a new value within 
+        // the variation range [color[i] - PLAYER_COLOR_VARIATION_RANGE, color[i] + PLAYER_COLOR_VARIATION_RANGE]
+        return _.map(color, function(channel) {
+            // Generate our offset in the range [-PLAYER_COLOR_VARIATION_RANGE, PLAYER_COLOR_VARIATION_RANGE]
+            var offset = Math.floor(Math.random() * ((PLAYER_COLOR_VARIATION_RANGE * 2) + 1)) - PLAYER_COLOR_VARIATION_RANGE;
+            return clampColorChannel(channel + offset);
+        });
+    };
+
+    var getColorPairForPlayerArmy = function(index, factionColor) {
+        // Host always gets the base faction color.
+        if (index === 0)
+            return _.cloneDeep(factionColor);
+
+        return [
+            randomizeColorNearFactionColor(factionColor[0]),
+            randomizeColorNearFactionColor(factionColor[1])
+        ];
+    };
+
+    var armyHasAI = function(army) {
+        return !!(army && _.isArray(army.slots) && _.any(army.slots, 'ai'));
+    };
+
+    var normalizeHumanArmiesForSharedControl = function(config, connectedClients) {
+        if (!config || !_.isArray(config.armies)) {
+            return;
+        }
+
+        if (!connectedClients || !_.isArray(connectedClients) || connectedClients.length === 0) {
+            console.log('[GW COOP] No connected clients found.');
+            return;
+        }
+
+        var humanArmyCount = 0;
+
+        // Figure out which army is the one in normal GW that would be marked
+        // as the human player (so we can then use it as a template to create more armies).
+        var humanTemplate;
+        _.forEach(config.armies, function(army) {
+            if (!armyHasAI(army)) {
+                humanTemplate = army;
+                humanArmyCount++;
+            }
+        });
+
+        if (humanArmyCount !== 1) {
+            console.log('[GW COOP] Expected exactly one human army, found ' + humanArmyCount + '.');
+            return;
+        }
+
+        if (!humanTemplate) {
+            console.log('[GW COOP] No human player template found.');
+            return;
+        }
+
+        var baseSlot = humanTemplate.slots && humanTemplate.slots[0];
+
+        if (!baseSlot) {
+            console.log('[GW COOP] No valid base slot found.');
+            return;
+        }
+
+        // Create a new army for each connected client.
+        var splitArmies = _.map(_.range(0, connectedClients.length), function(index) {
+            var slot = _.cloneDeep(baseSlot);
+            // Slots will be assigned to specific clients later in startGame().
+            delete slot.client;
+            delete slot.ai;
+            delete slot.name;
+
+            return {
+                slots: [slot],
+                // I assume here that humanTemplate.color is both a valid color and the main faction color.
+                color: getColorPairForPlayerArmy(index, humanTemplate.color),
+                econ_rate: _.has(humanTemplate, 'econ_rate') ? humanTemplate.econ_rate : 1,
+                spec_tag: humanTemplate.spec_tag,
+                alliance_group: humanTemplate.alliance_group
+            };
+        });
+
+        config.armies = _.reduce(config.armies, function(result, army) {
+            if (!armyHasAI(army)) {
+                return result.concat(splitArmies);
+            }
+
+            result.push(army);
+            return result;
+        }, []);
+
+        console.log('[GW COOP] - unshared control enabled; split humans into ' + splitArmies.length + ' allied armies');
+    };
+
     self.sendGWConfigToClient = function(client) {
         var config = self.config();
         if (!config || !config.files)
@@ -508,6 +615,12 @@ function LobbyModel(creator, launchContext) {
         var connectedClients = _.filter(server.clients, function(client) {
             return client.connected;
         });
+        var sharedControl = _.has(config, 'shared_control')
+            ? !!config.shared_control
+            : (_.has(self.launchContext, 'shared_control') ? !!self.launchContext.shared_control : true);
+
+        if (!sharedControl)
+            normalizeHumanArmiesForSharedControl(config, connectedClients);
 
         // Collect all human-controllable slots from non-AI armies.
         var humanSlots = [];
@@ -538,10 +651,15 @@ function LobbyModel(creator, launchContext) {
 
         // Map connected humans into human slots.
         _.forEach(humanSlots, function(slot, index) {
-            if (index < connectedClients.length)
-                slot.client = connectedClients[index];
-            else
+            if (index < connectedClients.length) {
+                var client = connectedClients[index];
+                slot.client = client;
+                slot.name = client.name || 'Player';
+            }
+            else {
                 delete slot.client;
+                delete slot.name;
+            }
         });
 
         // Set up the players array for the landing state
@@ -570,6 +688,7 @@ function LobbyModel(creator, launchContext) {
                     gw_campaign_host_id: self.creator,
                     gw_campaign_settings: _.cloneDeep(config.gw_campaign_settings || {}),
                     gw_campaign_access: _.cloneDeep(self.launchContext.access || {}),
+                    shared_control: sharedControl,
                     sandbox: config.sandbox,
                     eradication_mode: !!config.eradication_mode,
                     eradication_mode_sub_commanders: !!config.eradication_mode_sub_commanders,

--- a/server-script/states/playing.js
+++ b/server-script/states/playing.js
@@ -206,6 +206,19 @@ function isAI(army) {
     return !!result
 }
 
+function isGwCampaignHostArmy(army) {
+    if (!isGwCampaignCoopMatch() || !army)
+        return false;
+
+    var hostId = normalizeClientId(game_options && game_options.gw_campaign_host_id);
+    if (!hostId)
+        return false;
+
+    return _.some(army.players || [], function(player) {
+        return normalizeClientId(player && player.client && player.client.id) === hostId;
+    });
+}
+
 function spawnEffect(config) {
     var army = config.army && config.army.sim;
     var spec = config.spec;
@@ -564,13 +577,24 @@ function tickDefeatState(check_for_resurrection) {
             alive = _.some(army.commanders, function (commander) { return !commander.dead; });
         }
         if (!alive) {
-            if (isGalacticWar() && !isAI(army)) { /* in Galactic War, when the player is defeated we destroy all remaining subcommanders */
-                console.log('player died, so delete all their allies.');
-                var allies = _.filter(armies, function (target) {
-                    return isAlly(army, target) && isAI(target) && !target.defeated;
-                });
+            if (isGalacticWar() && !isAI(army)) { /* in Galactic War, when the host player is defeated we destroy all remaining subcommanders */
+                var defeatAlliedHumans = isGwCampaignHostArmy(army);
 
-                _.forEach(allies, defeatArmy);
+                if (!isGwCampaignCoopMatch() || defeatAlliedHumans) {
+                    console.log('player died, so delete all their allies.');
+                    console.log('[GW COOP] defeatAlliedHumans=' + JSON.stringify(defeatAlliedHumans));
+                    var allies = _.filter(armies, function (target) {
+                        if (!isAlly(army, target) || target.defeated)
+                            return false;
+
+                        if (isAI(target))
+                            return true;
+
+                        return defeatAlliedHumans && target !== army && !isAI(target);
+                    });
+
+                    _.forEach(allies, defeatArmy);
+                }
             }
 
             defeatArmy(army);

--- a/server-script/states/playing.js
+++ b/server-script/states/playing.js
@@ -135,7 +135,7 @@ function beginGwCampaignProcessRestart() {
             return client.id;
         });
 
-        console.log('[GW_COOP] sending restart_prepare from playing to connected clients=' + JSON.stringify(recipients));
+        console.log('[GW COOP] sending restart_prepare from playing to connected clients=' + JSON.stringify(recipients));
 
         server.broadcast({
             message_type: 'gw_return_to_campaign_restart_prepare',
@@ -162,7 +162,7 @@ function beginGwCampaignProcessRestart() {
     broadcastPrepare();
 
     _.delay(function() {
-        console.log('[GW_COOP] Executing process-level restart from playing after delay=' + GW_CAMPAIGN_RESTART_BROADCAST_DELAY_MS + 'ms');
+        console.log('[GW COOP] Executing process-level restart from playing after delay=' + GW_CAMPAIGN_RESTART_BROADCAST_DELAY_MS + 'ms');
 
         sim.onShutdown = server.exit;
         sim.shutdown(true);
@@ -942,7 +942,7 @@ exports.enter = function (config) {
                 if (gwCampaignRestartRequested)
                     return;
 
-                console.log('[GW_COOP] playing host disconnect shutdown reason=' + reason);
+                console.log('[GW COOP] playing host disconnect shutdown reason=' + reason);
                 sim.onShutdown = server.exit;
                 sim.shutdown(true);
             });

--- a/ui/main/game/galactic_war/gw_lobby/gw_lobby.js
+++ b/ui/main/game/galactic_war/gw_lobby/gw_lobby.js
@@ -363,7 +363,7 @@ $(document).ready(function() {
             return tagDone.promise();
         };
 
-        console.log('[GW_COOP] gw_lobby discovered local overlay unit tags ' + JSON.stringify(summarizeTaggedUnitLists(taggedUnitLists)));
+        console.log('[GW COOP] gw_lobby discovered local overlay unit tags ' + JSON.stringify(summarizeTaggedUnitLists(taggedUnitLists)));
 
         var gameId = ko.observable().extend({ local: 'gw_active_game' })();
         if (!gameId) {
@@ -424,7 +424,7 @@ $(document).ready(function() {
                             GW.specs.modSpecs(playerFiles, inventory.mods(), '.player');
                         } catch (e) {
                             var errorText = e && (e.stack || e.message || e.toString && e.toString());
-                            console.log('[GW_COOP] gw_lobby local overlay modSpecs failed error=' + (errorText || JSON.stringify(e))
+                            console.log('[GW COOP] gw_lobby local overlay modSpecs failed error=' + (errorText || JSON.stringify(e))
                                 + ' modCount=' + inventory.mods().length
                                 + ' playerFileCount=' + _.keys(playerFiles).length
                                 + ' mods=' + JSON.stringify(inventory.mods()));
@@ -438,7 +438,7 @@ $(document).ready(function() {
 
                     $.when.apply($, filesToProcess).then(function() {
                         var localFiles = _.assign.apply(_, [{}].concat(Array.prototype.slice.call(arguments)));
-                        console.log('[GW_COOP] gw_lobby local overlay files generated count=' + _.keys(localFiles).length);
+                        console.log('[GW COOP] gw_lobby local overlay files generated count=' + _.keys(localFiles).length);
                         done.resolve(localFiles);
                     });
                 }, function() {
@@ -479,7 +479,7 @@ $(document).ready(function() {
 
         buildLocalClientOverlayFiles(payload.files).always(function(localOverlayFiles) {
             var mergedFiles = _.assign({}, payload.files, _.isObject(localOverlayFiles) ? localOverlayFiles : {});
-            console.log('[GW_COOP] gw_lobby merging local overlay files', localOverlayFiles, mergedFiles);
+            console.log('[GW COOP] gw_lobby merging local overlay files', localOverlayFiles, mergedFiles);
 
             var cookedFiles = _.mapValues(mergedFiles, function(value) {
                 if (typeof value !== 'string')

--- a/ui/main/game/galactic_war/gw_play/gw_play.css
+++ b/ui/main/game/galactic_war/gw_play/gw_play.css
@@ -738,6 +738,21 @@ Otherwise things will look off.
     flex: 0 0 auto;
 }
 
+.gw-slot-share {
+    min-width: 130px;
+    height: 30px;
+    margin: 0 8px 0 0;
+    padding: 0 12px;
+    font-size: 14px;
+    line-height: 28px;
+    text-transform: uppercase;
+    flex: 0 0 auto;
+}
+
+.gw-slot-share .btn_toggle_label {
+    margin: 0;
+}
+
 .gw-slot-remove,
 .gw-campaign-slot-add {
     width: 32px;

--- a/ui/main/game/galactic_war/gw_play/gw_play.html
+++ b/ui/main/game/galactic_war/gw_play/gw_play.html
@@ -173,6 +173,9 @@
                         <span class="gw-slot-host" data-bind="visible: host"><loc> - Host</loc></span>
                     </div>
                     <img class="gw-slot-loading working small" src="coui://ui/main/shared/img/working.svg" data-placement="top" data-bind="visible: loading, tooltip: '!LOC:Loading into lobby'" />
+                    <div class="gw-slot-share btn_toggle" data-bind="visible: host, css: { live: $root.gwCampaignSharedControl(), btn_toggle_disabled: !$root.canEditGwCampaignLobby() }, click: $root.toggleGwCampaignSharedControl, click_sound: 'default', rollover_sound: 'default'">
+                        <div class="btn_std_label btn_toggle_label"><loc>Share Army</loc></div>
+                    </div>
                     <div class="gw-slot-kick" data-bind="visible: canKick && $root.canEditGwCampaignLobby(), click: function() { $root.kickGwCampaignClient($data); }, click_sound: 'default', rollover_sound: 'default'"><loc>Kick</loc></div>
                     <div class="gw-slot-remove" data-bind="visible: canRemove && $root.canEditGwCampaignLobby(), click: function() { $root.removeGwCampaignSlot($data); }, click_sound: 'default', rollover_sound: 'default'">-</div>
                 </div>

--- a/ui/main/game/galactic_war/gw_play/gw_play.js
+++ b/ui/main/game/galactic_war/gw_play/gw_play.js
@@ -45,7 +45,7 @@ requireGW([
         try {
             parsed = JSON.parse(raw);
         } catch (e) {
-            console.log('[GW_COOP] invalid required client mod session payload in gw_play; defaulting to empty list');
+            console.log('[GW COOP] invalid required client mod session payload in gw_play; defaulting to empty list');
             parsed = [];
         }
 
@@ -62,7 +62,7 @@ requireGW([
             seen[normalizedIdentifier] = true;
             normalized.push(normalizedIdentifier);
         });
-        console.log('[GW_COOP] read required client mod identifiers for gw_play', normalized);
+        console.log('[GW COOP] read required client mod identifiers for gw_play', normalized);
 
         return normalized;
     };
@@ -244,7 +244,7 @@ requireGW([
     };
 
     var runWithRequiredClientModsOnly = function(requiredIdentifiers, work) {
-        console.log('[GW_COOP] restricting client mods for gw_play', requiredIdentifiers);
+        console.log('[GW COOP] restricting client mods for gw_play', requiredIdentifiers);
         var communityModsManager = window.CommunityModsManager;
         var canRestrictClientMods = communityModsManager
             && _.isFunction(communityModsManager.installedMods)
@@ -291,7 +291,7 @@ requireGW([
         });
 
         communityModsManager.installedMods.valueHasMutated();
-        console.log('[GW_COOP] gw_play restricting client mods for shared referee generation required=' + JSON.stringify(_.keys(requiredLookup)));
+        console.log('[GW COOP] gw_play restricting client mods for shared referee generation required=' + JSON.stringify(_.keys(requiredLookup)));
 
         communityModsManager.remountClientMods().always(function() {
             $.when(work()).always(function() {
@@ -307,7 +307,7 @@ requireGW([
                 });
 
                 communityModsManager.installedMods.valueHasMutated();
-                console.log('[GW_COOP] gw_play restoring full client mod set after shared referee generation');
+                console.log('[GW COOP] gw_play restoring full client mod set after shared referee generation');
 
                 communityModsManager.remountClientMods().always(function() {
                     done.resolve();
@@ -319,7 +319,7 @@ requireGW([
     };
 
     var hireRefereesForLaunch = function(game, isolateSharedSpecs) {
-        console.log('[GW_COOP] hiring referees for gw_play launch; isolateSharedSpecs=' + !!isolateSharedSpecs);
+        console.log('[GW COOP] hiring referees for gw_play launch; isolateSharedSpecs=' + !!isolateSharedSpecs);
         var done = $.Deferred();
 
         if (!isolateSharedSpecs) {
@@ -344,7 +344,7 @@ requireGW([
             });
         }).always(function() {
             if (!sharedRefereeReady) {
-                console.log('[GW_COOP] failed to build clean shared referee; aborting launch to avoid contaminated gw_config');
+                console.log('[GW COOP] failed to build clean shared referee; aborting launch to avoid contaminated gw_config');
                 done.resolve({
                     sharedReferee: undefined,
                     localReferee: undefined
@@ -1419,14 +1419,14 @@ requireGW([
         };
 
         self.applySavedCoopSettingsToCampaignLobby = function() {
-            console.log('[GW_COOP] applying saved coop slot settings to campaign lobby');
+            console.log('[GW COOP] applying saved coop slot settings to campaign lobby');
             if (self.initialCoopSettingsApplied) {
-                console.log('[GW_COOP] already applied saved coop slot settings, skipping');
+                console.log('[GW COOP] already applied saved coop slot settings, skipping');
                 return;
             }
 
             if (!self.isCampaignHost() || !self.gwCampaignConnected()) {
-                console.log('[GW_COOP] not campaign host or not connected, skipping applying saved coop slot settings');
+                console.log('[GW COOP] not campaign host or not connected, skipping applying saved coop slot settings');
                 return;
             }
 
@@ -1434,10 +1434,10 @@ requireGW([
             var playersLocked = self.savedCoopPlayersLocked();
             var sharedByDefault = self.savedSharedByDefault();
 
-            console.log('[GW_COOP] saved coop players specified: ' + playersSpecified + ', locked: ' + playersLocked + ', shared: ' + sharedByDefault);
+            console.log('[GW COOP] saved coop players specified: ' + playersSpecified + ', locked: ' + playersLocked + ', shared: ' + sharedByDefault);
             if (!playersSpecified && !playersLocked && sharedByDefault) {
                 self.initialCoopSettingsApplied = true;
-                console.log('[GW_COOP] no saved coop settings to apply, marking as applied');
+                console.log('[GW COOP] no saved coop settings to apply, marking as applied');
                 return;
             }
 
@@ -1445,10 +1445,10 @@ requireGW([
             var players = self.savedCoopPlayers();
             var payload = self.buildCampaignLobbySettingsPayload(players);
 
-            console.log('[GW_COOP] applying saved coop slot settings: ' + JSON.stringify(payload));
+            console.log('[GW COOP] applying saved coop slot settings: ' + JSON.stringify(payload));
             self.initialCoopSettingsApplied = true;
             self.send_message('modify_settings', payload, function(success, response) {
-                console.log('[GW_COOP] applied saved coop slot settings success=' + !!success + ' payload=' + JSON.stringify(payload || {}) + ' response=' + JSON.stringify(response || {}));
+                console.log('[GW COOP] applied saved coop slot settings success=' + !!success + ' payload=' + JSON.stringify(payload || {}) + ' response=' + JSON.stringify(response || {}));
             });
         };
 
@@ -1490,7 +1490,7 @@ requireGW([
         // "authoritative" and ready for the player to start playing.
         self.markGwCampaignAuthoritativeStateReady = function(reason) {
             if (!self.gwCampaignAuthoritativeStateReady())
-                console.log('[GW_COOP] authoritative campaign state ready reason=' + (reason || 'unknown'));
+                console.log('[GW COOP] authoritative campaign state ready reason=' + (reason || 'unknown'));
 
             self.gwCampaignAuthoritativeStateReady(true);
 
@@ -1789,7 +1789,7 @@ requireGW([
             });
 
             if (enrichedSystems > 0)
-                console.log('[GW_COOP] enrichCampaignGameSystems reason=' + reason + ' enriched=' + enrichedSystems);
+                console.log('[GW COOP] enrichCampaignGameSystems reason=' + reason + ' enriched=' + enrichedSystems);
 
             return enrichedSystems;
         };
@@ -1804,7 +1804,7 @@ requireGW([
 
             // Skip saving because the local state is likely incomplete or inaccurate.
             if (self.gwCampaignAuthoritativeStateRequired && !self.gwCampaignAuthoritativeStateReady()) {
-                console.log('[GW_COOP] persistCampaignLocalCopy skipped before authoritative campaign state reason=' + reason);
+                console.log('[GW COOP] persistCampaignLocalCopy skipped before authoritative campaign state reason=' + reason);
                 done.resolve();
                 return done.promise();
             }
@@ -1822,10 +1822,10 @@ requireGW([
             }
 
             saving.then(function() {
-                console.log('[GW_COOP] persistCampaignLocalCopy saved reason=' + reason);
+                console.log('[GW COOP] persistCampaignLocalCopy saved reason=' + reason);
                 done.resolve();
             }, function(err) {
-                console.error('[GW_COOP] persistCampaignLocalCopy failed reason=' + reason, err);
+                console.error('[GW COOP] persistCampaignLocalCopy failed reason=' + reason, err);
                 done.resolve();
             });
 
@@ -1857,7 +1857,7 @@ requireGW([
             }
 
             if (enrichedSystems > 0)
-                console.log('[GW_COOP] snapshot enriched missing systems=' + enrichedSystems);
+                console.log('[GW COOP] snapshot enriched missing systems=' + enrichedSystems);
 
             return {
                 game: gameSave,
@@ -1970,7 +1970,7 @@ requireGW([
                             star: exploreStarIndex,
                             cards: exploreStar && _.isFunction(exploreStar.cardList) ? exploreStar.cardList() : []
                         });
-                        console.log('[GW_COOP] wrapped explore relayed sync_star_cards reason=' + reason + ' star=' + exploreStarIndex);
+                        console.log('[GW COOP] wrapped explore relayed sync_star_cards reason=' + reason + ' star=' + exploreStarIndex);
                     };
 
                     if (exploreStar && _.isFunction(exploreStar.cardList) && _.isFunction(exploreStar.cardList.subscribe)) {
@@ -2000,7 +2000,7 @@ requireGW([
             wrapped.__gwCampaignWrappedName = name;
             wrapped.__gwCampaignWrappedOriginal = current;
             self[name] = wrapped;
-            console.log('[GW_COOP] wrapped external override for ' + name + ' to preserve co-op sync');
+            console.log('[GW COOP] wrapped external override for ' + name + ' to preserve co-op sync');
         };
 
         self.ensureCampaignCompatibilityHooks = function() {
@@ -2064,7 +2064,7 @@ requireGW([
             copyObservable('coordinates', true);
 
             if (changed)
-                console.log('[GW_COOP] syncViewerStarFromGame star=' + starIndex + ' reason=' + reason);
+                console.log('[GW COOP] syncViewerStarFromGame star=' + starIndex + ' reason=' + reason);
 
             return changed;
         };
@@ -2089,7 +2089,7 @@ requireGW([
             }
 
             if (changedCount > 0)
-                console.log('[GW_COOP] syncViewerStarsFromGame reason=' + reason + ' changed=' + changedCount);
+                console.log('[GW COOP] syncViewerStarsFromGame reason=' + reason + ' changed=' + changedCount);
         };
 
         self.getGalaxySignature = function(galaxyData) {
@@ -2135,7 +2135,7 @@ requireGW([
             var snapshot = payload.snapshot;
             var ui = snapshot.ui || {};
             var incomingSeq = _.isNumber(payload.seq) ? payload.seq : 0;
-            console.log('[GW_COOP] applyCampaignSnapshot start seq=' + incomingSeq + ' applying=' + self.gwCampaignApplyingSnapshot);
+            console.log('[GW COOP] applyCampaignSnapshot start seq=' + incomingSeq + ' applying=' + self.gwCampaignApplyingSnapshot);
 
             var localGalaxy = game.galaxy && game.galaxy();
             var localSignature = self.getGalaxySignature(localGalaxy);
@@ -2143,7 +2143,7 @@ requireGW([
 
             if (!self.gwCampaignHydrationInProgress && snapshotSignature && localSignature !== snapshotSignature) {
                 self.gwCampaignHydrationInProgress = true;
-                console.log('[GW_COOP] snapshot galaxy mismatch local=' + localSignature + ' remote=' + snapshotSignature + ', forcing full rehydrate');
+                console.log('[GW COOP] snapshot galaxy mismatch local=' + localSignature + ' remote=' + snapshotSignature + ', forcing full rehydrate');
 
                 var hydratedGame = new GW.Game();
                 hydratedGame.load(snapshot.game).always(function() {
@@ -2155,12 +2155,12 @@ requireGW([
                             sessionStorage.setItem('gw_campaign_authoritative_game_id', String(hydratedGame.id));
                         }
                         catch (e) {
-                            console.warn('[GW_COOP] failed to set authoritative game id in sessionStorage', e);
+                            console.warn('[GW COOP] failed to set authoritative game id in sessionStorage', e);
                         }
                         window.location.reload();
                     }, function(err) {
                         self.gwCampaignHydrationInProgress = false;
-                        console.error('[GW_COOP] failed to save hydrated game', err);
+                        console.error('[GW COOP] failed to save hydrated game', err);
                     });
                 });
                 return;
@@ -2176,7 +2176,7 @@ requireGW([
 
                 self.markGwCampaignAuthoritativeStateReady('snapshot_seq_' + incomingSeq);
 
-                console.log('[GW_COOP] applyCampaignSnapshot done seq=' + incomingSeq + ' currentStar=' + game.currentStar() + ' selected=' + self.selection.star());
+                console.log('[GW COOP] applyCampaignSnapshot done seq=' + incomingSeq + ' currentStar=' + game.currentStar() + ' selected=' + self.selection.star());
 
                 self.gwCampaignApplyingSnapshot = false;
 
@@ -2199,14 +2199,14 @@ requireGW([
             var hasCardBeforeAction = currentSystemBeforeAction && currentSystemBeforeAction.star && _.isFunction(currentSystemBeforeAction.star.hasCard) ? currentSystemBeforeAction.star.hasCard() : undefined;
             var historyBeforeAction = currentSystemBeforeAction && currentSystemBeforeAction.star && _.isFunction(currentSystemBeforeAction.star.history) ? (currentSystemBeforeAction.star.history() || []).length : undefined;
 
-            console.log('[GW_COOP] applyCampaignAction recv type=' + action.type + ' currentStar=' + currentStarBeforeAction + ' hasAi=' + !!aiBeforeAction + ' hasCard=' + hasCardBeforeAction + ' history=' + historyBeforeAction);
+            console.log('[GW COOP] applyCampaignAction recv type=' + action.type + ' currentStar=' + currentStarBeforeAction + ' hasAi=' + !!aiBeforeAction + ' hasCard=' + hasCardBeforeAction + ' history=' + historyBeforeAction);
             self.syncViewerStarsFromGame('before_action_' + action.type, [currentStarBeforeAction]);
             self.gwCampaignReplayingAction = true;
 
             if (action.type === 'startup_battle_result' && payload && payload.result) {
                 if (payload.result === 'win') {
                     game.winTurn().then(function(didWin) {
-                        console.log('[GW_COOP] applyCampaignAction startup_battle_result win didWin=' + didWin + ' currentStar=' + game.currentStar());
+                        console.log('[GW COOP] applyCampaignAction startup_battle_result win didWin=' + didWin + ' currentStar=' + game.currentStar());
                         GW.manifest.saveGame(game);
                     });
                 }
@@ -2214,7 +2214,7 @@ requireGW([
                     var didLose = game.loseTurn();
                     if (game.isTutorial())
                         game.turnState(GW.Game.turnStates.begin);
-                    console.log('[GW_COOP] applyCampaignAction startup_battle_result loss didLose=' + didLose + ' currentStar=' + game.currentStar());
+                    console.log('[GW COOP] applyCampaignAction startup_battle_result loss didLose=' + didLose + ' currentStar=' + game.currentStar());
                     GW.manifest.saveGame(game);
                 }
 
@@ -2293,7 +2293,7 @@ requireGW([
 
             if (action.type === 'win_turn') {
                 // Viewer can be out of the precise turn micro-state; use snapshot correction instead.
-                console.log('[GW_COOP] applyCampaignAction win_turn fallback->snapshot');
+                console.log('[GW COOP] applyCampaignAction win_turn fallback->snapshot');
                 self.requestCampaignSnapshot();
                 self.gwCampaignReplayingAction = false;
                 return;
@@ -2324,7 +2324,7 @@ requireGW([
             if (!payload || payload.state !== 'gw_campaign')
                 return;
 
-            console.log('[GW_COOP] server_state gw_campaign url=' + payload.url);
+            console.log('[GW COOP] server_state gw_campaign url=' + payload.url);
             self.gwCampaignEnabled(true);
             self.gwCampaignConnected(true);
 
@@ -2368,7 +2368,7 @@ requireGW([
             }
             self.requestCampaignChatHistory();
 
-            console.log('[GW_COOP] gw_campaign role from server_state=' + (role || '<unchanged>'));
+            console.log('[GW COOP] gw_campaign role from server_state=' + (role || '<unchanged>'));
 
             if (self.isCampaignHost())
                 self.markGwCampaignAuthoritativeStateReady('server_state_host');
@@ -2500,7 +2500,7 @@ requireGW([
                 ].join('|');
                 if (self.gwCampaignOwnerStateDebug[star] !== ownerKey) {
                     self.gwCampaignOwnerStateDebug[star] = ownerKey;
-                    console.log('[GW_COOP] ownerColorState star=' + star + ' source=' + ownerSource + ' connected=' + system.connected() + ' hasAi=' + !!ai + ' hasCard=' + system.star.hasCard() + ' history=' + historyCount + ' owner=' + (owner ? owner.join(',') : 'none') + ' role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction);
+                    console.log('[GW COOP] ownerColorState star=' + star + ' source=' + ownerSource + ' connected=' + system.connected() + ' hasAi=' + !!ai + ' hasCard=' + system.star.hasCard() + ' history=' + historyCount + ' owner=' + (owner ? owner.join(',') : 'none') + ' role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction);
                 }
 
                 if (boss && !bossModel) {
@@ -2750,7 +2750,7 @@ requireGW([
                 var visitedBeforeMove = system.visited();
 
                 if (!system.visited()) {
-                    console.log('[GW_COOP] revealSystem trigger star=' + star + ' role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction);
+                    console.log('[GW COOP] revealSystem trigger star=' + star + ' role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction);
                     self.revealSystem(system);
                 }
 
@@ -2758,7 +2758,7 @@ requireGW([
 
                 // Some viewer replays can miss the internal move mutation. Force minimal sync fallback.
                 if (self.isCampaignViewer() && game.currentStar() !== star) {
-                    console.log('[GW_COOP] viewer move fallback set currentStar from=' + game.currentStar() + ' to=' + star);
+                    console.log('[GW COOP] viewer move fallback set currentStar from=' + game.currentStar() + ' to=' + star);
                     game.currentStar(star);
                 }
 
@@ -2767,7 +2767,7 @@ requireGW([
                     if (replayStar && _.isFunction(replayStar.history)) {
                         var history = replayStar.history() || [];
                         replayStar.history(history.concat([{ coop_replay: true, t: _.now() }]));
-                        console.log('[GW_COOP] viewer move fallback marked visited star=' + star);
+                        console.log('[GW COOP] viewer move fallback marked visited star=' + star);
                     }
                 }
 
@@ -2889,7 +2889,7 @@ requireGW([
             if (self.isCampaignViewer() && !self.gwCampaignReplayingAction)
                 return;
 
-            console.log('[GW_COOP] win start selected=' + selected_card_index + ' role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction + ' currentStar=' + game.currentStar() + ' turnState=' + game.turnState() + ' gameState=' + game.gameState());
+            console.log('[GW COOP] win start selected=' + selected_card_index + ' role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction + ' currentStar=' + game.currentStar() + ' turnState=' + game.turnState() + ' gameState=' + game.gameState());
 
             if (!self.gwCampaignReplayingAction)
                 self.sendCampaignAction('win_choice', { selected_card_index: selected_card_index });
@@ -2907,7 +2907,7 @@ requireGW([
             game.winTurn(selected_card_index).then(function(didWin) {
                 if (!didWin) {
                     console.error('Failed winning turn', game);
-                    console.log('[GW_COOP] win failed role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction + ' currentStar=' + game.currentStar() + ' turnState=' + game.turnState() + ' gameState=' + game.gameState());
+                    console.log('[GW COOP] win failed role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction + ' currentStar=' + game.currentStar() + ' turnState=' + game.turnState() + ' gameState=' + game.gameState());
                     return;
                 }
 
@@ -2915,7 +2915,7 @@ requireGW([
                 var winAi = winStar && _.isFunction(winStar.ai) ? winStar.ai() : undefined;
                 var winHasCard = winStar && _.isFunction(winStar.hasCard) ? winStar.hasCard() : undefined;
                 var winHistory = winStar && _.isFunction(winStar.history) ? (winStar.history() || []).length : undefined;
-                console.log('[GW_COOP] win applied role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction + ' currentStar=' + game.currentStar() + ' hasAi=' + !!winAi + ' hasCard=' + winHasCard + ' history=' + winHistory + ' turnState=' + game.turnState() + ' gameState=' + game.gameState());
+                console.log('[GW COOP] win applied role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction + ' currentStar=' + game.currentStar() + ' hasAi=' + !!winAi + ' hasCard=' + winHasCard + ' history=' + winHistory + ' turnState=' + game.turnState() + ' gameState=' + game.gameState());
 
                 if (self.isCampaignViewer())
                     self.syncViewerStarsFromGame('win_applied');
@@ -2951,7 +2951,7 @@ requireGW([
             if (self.isCampaignViewer() && !self.gwCampaignReplayingAction)
                 return;
 
-            console.log('[GW_COOP] lose start role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction + ' currentStar=' + game.currentStar() + ' turnState=' + game.turnState() + ' gameState=' + game.gameState());
+            console.log('[GW COOP] lose start role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction + ' currentStar=' + game.currentStar() + ' turnState=' + game.turnState() + ' gameState=' + game.gameState());
 
             if (!self.gwCampaignReplayingAction)
                 self.sendCampaignAction('lose_turn', {});
@@ -2962,7 +2962,7 @@ requireGW([
                 var loseAi = loseStar && _.isFunction(loseStar.ai) ? loseStar.ai() : undefined;
                 var loseHasCard = loseStar && _.isFunction(loseStar.hasCard) ? loseStar.hasCard() : undefined;
                 var loseHistory = loseStar && _.isFunction(loseStar.history) ? (loseStar.history() || []).length : undefined;
-                console.log('[GW_COOP] lose applied role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction + ' currentStar=' + game.currentStar() + ' hasAi=' + !!loseAi + ' hasCard=' + loseHasCard + ' history=' + loseHistory + ' turnState=' + game.turnState() + ' gameState=' + game.gameState());
+                console.log('[GW COOP] lose applied role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction + ' currentStar=' + game.currentStar() + ' hasAi=' + !!loseAi + ' hasCard=' + loseHasCard + ' history=' + loseHistory + ' turnState=' + game.turnState() + ' gameState=' + game.gameState());
 
                 if (self.isCampaignViewer())
                     self.syncViewerStarsFromGame('lose_applied');
@@ -2975,7 +2975,7 @@ requireGW([
                 });
             }
             else {
-                console.log('[GW_COOP] lose failed role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction + ' currentStar=' + game.currentStar() + ' turnState=' + game.turnState() + ' gameState=' + game.gameState());
+                console.log('[GW COOP] lose failed role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction + ' currentStar=' + game.currentStar() + ' turnState=' + game.turnState() + ' gameState=' + game.gameState());
                 self.exitGate().resolve();
             }
         };
@@ -3043,7 +3043,7 @@ requireGW([
                 var localReferee = refereeBundle && refereeBundle.localReferee;
 
                 if (!referee) {
-                    console.log('[GW_COOP] failed to hire GW referee for launch');
+                    console.log('[GW COOP] failed to hire GW referee for launch');
                     self.launchingFight(false);
                     return;
                 }
@@ -3054,7 +3054,7 @@ requireGW([
                     if (_.isObject(personalizedFiles))
                         localFiles = _.cloneDeep(personalizedFiles);
                 }
-                console.log('[GW_COOP] personalizedFiles for launch', localFiles);
+                console.log('[GW COOP] personalizedFiles for launch', localFiles);
 
                 localFiles['/ui/main/game/live_game/live_game.js'] = patchedLiveGameScript;
                 referee.localFiles(localFiles);
@@ -3436,7 +3436,7 @@ requireGW([
 
         self.revealSystem = function(system) {
             if (!system) {
-                console.log('[GW_COOP] revealSystem skipped: no system role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction);
+                console.log('[GW COOP] revealSystem skipped: no system role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction);
                 return;
             }
 
@@ -3446,14 +3446,14 @@ requireGW([
             });
             var hasAi = !!(system.star.ai && system.star.ai());
             var hasBoss = !!(hasAi && system.star.ai().boss);
-            console.log('[GW_COOP] revealSystem role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction + ' newNeighbors=' + newNeighbors.length + ' hasAi=' + hasAi + ' hasBoss=' + hasBoss);
+            console.log('[GW COOP] revealSystem role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction + ' newNeighbors=' + newNeighbors.length + ' hasAi=' + hasAi + ' hasBoss=' + hasBoss);
 
             if (newBoss) {
-                console.log('[GW_COOP] cue board_commander_factionleader_discovered');
+                console.log('[GW COOP] cue board_commander_factionleader_discovered');
                 api.audio.playSound('/VO/Computer/gw/board_commander_factionleader_discovered');
             }
             else if (system.star.ai() && !system.star.ai().boss) {
-                console.log('[GW_COOP] cue board_commander_discovered');
+                console.log('[GW COOP] cue board_commander_discovered');
                 api.audio.playSound('/VO/Computer/gw/board_commander_discovered');
             }
         };
@@ -3468,23 +3468,23 @@ requireGW([
         self.maybePlayCaptureSound = function() {
             var currentStar = self.currentStar();
             if (!currentStar) {
-                console.log('[GW_COOP] maybePlayCaptureSound no currentStar role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction);
+                console.log('[GW COOP] maybePlayCaptureSound no currentStar role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction);
                 return false;
             }
 
             if (currentStar.ai()) {
-                console.log('[GW_COOP] maybePlayCaptureSound blocked: ai present star=' + game.currentStar());
+                console.log('[GW COOP] maybePlayCaptureSound blocked: ai present star=' + game.currentStar());
                 return false;
             }
 
             var history = currentStar.history();
             var last = history[history.length - 1];
             if (!last || !last.details || !last.details.win || !last.details.win.ai) {
-                console.log('[GW_COOP] maybePlayCaptureSound blocked: no capture history star=' + game.currentStar() + ' history=' + history.length);
+                console.log('[GW COOP] maybePlayCaptureSound blocked: no capture history star=' + game.currentStar() + ' history=' + history.length);
                 return false;
             }
 
-            console.log('[GW_COOP] cue board_system_capture star=' + game.currentStar() + ' role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction);
+            console.log('[GW COOP] cue board_system_capture star=' + game.currentStar() + ' role=' + self.gwCampaignRole() + ' replay=' + self.gwCampaignReplayingAction);
             api.audio.playSound('/VO/Computer/gw/board_system_capture');
             return true;
         };
@@ -3562,7 +3562,7 @@ requireGW([
 
             if (self.isCampaignHost() && self.gwCampaignConnected() && self.gwCampaignStartupBattleResult && !self.gwCampaignStartupResultSent) {
                 self.gwCampaignStartupResultSent = true;
-                console.log('[GW_COOP] host relaying startup_battle_result=' + self.gwCampaignStartupBattleResult);
+                console.log('[GW COOP] host relaying startup_battle_result=' + self.gwCampaignStartupBattleResult);
                 self.sendCampaignAction('startup_battle_result', { result: self.gwCampaignStartupBattleResult });
             }
 
@@ -3689,7 +3689,7 @@ requireGW([
         if (game || !gwCampaignCoopMode)
             return game;
 
-        console.log('[GW_COOP] no local gw_active_game found, creating hidden co-op bootstrap game coopMode=' + gwCampaignCoopMode + ' queryMode=' + gwCampaignMode);
+        console.log('[GW COOP] no local gw_active_game found, creating hidden co-op bootstrap game coopMode=' + gwCampaignCoopMode + ' queryMode=' + gwCampaignMode);
         return new GW.Game();
     });
     var documentLoader = $(document).ready();
@@ -3727,7 +3727,7 @@ requireGW([
         // If the game fails to load, going back is better than getting stuck.
         if (!game) {
             // TODO: Maybe tell the player what's up?
-            console.log('[GW_COOP] failed to load game, exiting to main menu');
+            console.log('[GW COOP] failed to load game, exiting to main menu');
             self.exitGame();
             return;
         }
@@ -3739,7 +3739,7 @@ requireGW([
         // process any battle results.
         var battleResult = game.lastBattleResult();
         var startupBattleResult = null;
-        console.log('[GW_COOP] startup battleResult=' + battleResult + ' currentStar=' + game.currentStar());
+        console.log('[GW COOP] startup battleResult=' + battleResult + ' currentStar=' + game.currentStar());
 
         if (battleResult)
         {
@@ -3747,13 +3747,13 @@ requireGW([
             startupBattleResult = battleResult;
             if (battleResult === 'win')
                 game.winTurn().then(function() {
-                    console.log('[GW_COOP] startup battleResult winTurn applied currentStar=' + game.currentStar());
+                    console.log('[GW COOP] startup battleResult winTurn applied currentStar=' + game.currentStar());
                     GW.manifest.saveGame(game);
                 });
 
             if (battleResult === 'loss') {
                 game.loseTurn();
-                console.log('[GW_COOP] startup battleResult loseTurn applied currentStar=' + game.currentStar());
+                console.log('[GW COOP] startup battleResult loseTurn applied currentStar=' + game.currentStar());
                 if (game.isTutorial()) {
                     game.turnState(GW.Game.turnStates.begin);
                 }
@@ -3800,7 +3800,7 @@ requireGW([
             ].join('|');
             if (model.gwCampaignLastControlLogKey !== controlLogKey) {
                 model.gwCampaignLastControlLogKey = controlLogKey;
-                console.log('[GW_COOP] gw_campaign_control seq=' + (payload && payload.snapshot_seq) + ' hasSnapshot=' + !!(payload && payload.has_snapshot));
+                console.log('[GW COOP] gw_campaign_control seq=' + (payload && payload.snapshot_seq) + ' hasSnapshot=' + !!(payload && payload.has_snapshot));
             }
             model.gwCampaignControl(payload || {});
 
@@ -3838,7 +3838,7 @@ requireGW([
             var roleLogKey = [payload.role, payload.host_id, payload.host_name].join('|');
             if (model.gwCampaignLastRoleLogKey !== roleLogKey) {
                 model.gwCampaignLastRoleLogKey = roleLogKey;
-                console.log('[GW_COOP] gw_campaign_role=' + payload.role + ' host=' + payload.host_name);
+                console.log('[GW COOP] gw_campaign_role=' + payload.role + ' host=' + payload.host_name);
             }
             var previousRole = model.gwCampaignRole();
             model.gwCampaignEnabled(true);
@@ -3895,7 +3895,7 @@ requireGW([
         };
 
         handlers.gw_campaign_snapshot = function(payload) {
-            console.log('[GW_COOP] gw_campaign_snapshot recv seq=' + (payload && payload.seq) + ' reason=' + (payload && payload.reason));
+            console.log('[GW COOP] gw_campaign_snapshot recv seq=' + (payload && payload.seq) + ' reason=' + (payload && payload.reason));
             model.applyCampaignSnapshot(payload);
         };
 

--- a/ui/main/game/galactic_war/gw_play/gw_play.js
+++ b/ui/main/game/galactic_war/gw_play/gw_play.js
@@ -1278,6 +1278,7 @@ requireGW([
         // This is a hard limit that is not allowed to be exceeded, and is used to cap the maximum value of gwCampaignMaxClients.
         self.gwCampaignMaxClientsLimit = ko.observable(6);
         self.gwCampaignMaxClientsLocked = ko.observable(false);
+        self.gwCampaignSharedControl = ko.observable(true);
         self.initialCoopSettingsApplied = false;
 
         var getQueryParam = function(name) {
@@ -1388,6 +1389,10 @@ requireGW([
             return !!(game && _.isFunction(game.lockCoopPlayers) && game.lockCoopPlayers());
         };
 
+        self.savedSharedByDefault = function() {
+            return !(game && _.isFunction(game.sharedByDefault) && game.sharedByDefault() === false);
+        };
+
         self.buildCampaignLobbySettingsPayload = function(maxClients) {
             var mode = self.visibilityMode();
             // Tag here is 'Testing', but perhaps should not be hardcoded?
@@ -1397,6 +1402,7 @@ requireGW([
                 public: mode === 'public',
                 friends: mode === 'friends' ? self.friends() : [],
                 password: self.privateGamePassword(),
+                shared_control: self.gwCampaignSharedControl(),
                 tag: 'Testing'
             };
 
@@ -1426,14 +1432,16 @@ requireGW([
 
             var playersSpecified = self.savedCoopPlayersSpecified();
             var playersLocked = self.savedCoopPlayersLocked();
+            var sharedByDefault = self.savedSharedByDefault();
 
-            console.log('[GW_COOP] saved coop players specified: ' + playersSpecified + ', locked: ' + playersLocked);
-            if (!playersSpecified && !playersLocked) {
+            console.log('[GW_COOP] saved coop players specified: ' + playersSpecified + ', locked: ' + playersLocked + ', shared: ' + sharedByDefault);
+            if (!playersSpecified && !playersLocked && sharedByDefault) {
                 self.initialCoopSettingsApplied = true;
                 console.log('[GW_COOP] no saved coop settings to apply, marking as applied');
                 return;
             }
 
+            self.gwCampaignSharedControl(sharedByDefault);
             var players = self.savedCoopPlayers();
             var payload = self.buildCampaignLobbySettingsPayload(players);
 
@@ -1596,6 +1604,9 @@ requireGW([
             if (_.has(data, 'max_clients_locked'))
                 self.gwCampaignMaxClientsLocked(!!data.max_clients_locked);
 
+            if (_.has(data, 'shared_control'))
+                self.gwCampaignSharedControl(!!data.shared_control);
+
             if (!_.has(data, 'settings') || !data.settings)
                 return;
 
@@ -1624,6 +1635,14 @@ requireGW([
             self.send_message('modify_settings', self.buildCampaignLobbySettingsPayload(self.gwCampaignMaxClients()));
         };
 
+        self.toggleGwCampaignSharedControl = function() {
+            if (!self.canEditGwCampaignLobby() || !self.gwCampaignActive())
+                return;
+
+            self.gwCampaignSharedControl(!self.gwCampaignSharedControl());
+            self.pushCampaignLobbySettings();
+        };
+
         // Applies one-time restart context after host reconnects to a newly
         // started gw_campaign server process. This keeps co-op lobby settings stable
         // across process-level Continue War restarts.
@@ -1642,6 +1661,7 @@ requireGW([
                 game_name: _.isString(settings.game_name) ? settings.game_name : self.gwLobbyTitle(),
                 tag: _.isString(settings.tag) ? settings.tag : 'Testing',
                 public: _.isBoolean(settings.public) ? settings.public : true,
+                shared_control: _.has(context, 'shared_control') ? !!context.shared_control : (_.has(settings, 'shared_control') ? !!settings.shared_control : self.gwCampaignSharedControl()),
                 max_clients: _.isFinite(settings.max_clients) ? settings.max_clients : self.gwCampaignMaxClients(),
                 password: _.isString(access.password) ? access.password : self.privateGamePassword(),
                 friends: _.isArray(access.friends) ? access.friends : [],
@@ -3054,6 +3074,7 @@ requireGW([
                         '/ui/main/game/live_game/live_game.js': patchedLiveGameScript
                     });
                     battleConfig.gw_campaign_active = !!self.gwCampaignActive();
+                    battleConfig.shared_control = self.gwCampaignActive() ? self.gwCampaignSharedControl() : true;
 
                     // Mirror current campaign lobby presentation settings so the
                     // battle lobby beacon can continue the same identity.
@@ -3065,6 +3086,7 @@ requireGW([
                         public: _.isBoolean(campaignSettings.public) ? campaignSettings.public : true,
                         friends: !!campaignSettings.friends,
                         hidden: !!campaignSettings.hidden,
+                        shared_control: battleConfig.shared_control,
                         max_clients: _.isFinite(campaignControl.max_clients) ? campaignControl.max_clients : undefined
                     };
 
@@ -3106,7 +3128,8 @@ requireGW([
                         self.send_message('launch_gw_battle', {
                             current_star: game.currentStar(),
                             gw_campaign_active: true,
-                            gw_campaign_settings: battleConfig.gw_campaign_settings
+                            gw_campaign_settings: battleConfig.gw_campaign_settings,
+                            shared_control: battleConfig.shared_control
                         });
                         return;
                     }

--- a/ui/main/game/galactic_war/gw_play/live_game_patch.js
+++ b/ui/main/game/galactic_war/gw_play/live_game_patch.js
@@ -47,6 +47,7 @@
                 host_id: clientState.gw_campaign_host_id,
                 settings: settings,
                 access: access,
+                shared_control: _.has(settings, 'shared_control') ? !!settings.shared_control : true,
                 content: (_.isFunction(loadedGwGame && loadedGwGame.content) ? loadedGwGame.content() : undefined) || gameContent() || reconnectInfo.content,
                 use_local_server: !!useLocalServer(),
                 mods: reconnectInfo.mods || []

--- a/ui/main/game/galactic_war/gw_play/live_game_patch.js
+++ b/ui/main/game/galactic_war/gw_play/live_game_patch.js
@@ -76,7 +76,7 @@
             context.pending_reapply = (role === 'host');
             gwCampaignRestartContext(context);
             gwCampaignRestartNavigating = true;
-            console.log('[GW_COOP] navigateForCampaignRestart role=' + role + ' shutdownDelay=' + context.shutdown_delay_ms);
+            console.log('[GW COOP] navigateForCampaignRestart role=' + role + ' shutdownDelay=' + context.shutdown_delay_ms);
 
             // Mark disconnect as user-triggered so live_game native disconnect
             // handlers do not force transit back to main menu.
@@ -340,7 +340,7 @@
 
         // Server tells all clients to prepare for full server process restart.
         handlers.gw_return_to_campaign_restart_prepare = function(payload) {
-            console.log('[GW_COOP] gw_return_to_campaign_restart_prepare received payload=' + JSON.stringify(payload));
+            console.log('[GW COOP] gw_return_to_campaign_restart_prepare received payload=' + JSON.stringify(payload));
             var preparePayload = payload || {};
             var inferredRole = gwCampaignRole();
 
@@ -366,7 +366,7 @@
 
             gwCampaignRole(inferredRole);
 
-            console.log('[GW_COOP] restart_prepare received role=' + gwCampaignRole() + ' token=' + preparePayload.restart_token + ' delay=' + preparePayload.shutdown_delay_ms + ' host=' + preparePayload.host_id + ' name=' + displayName());
+            console.log('[GW COOP] restart_prepare received role=' + gwCampaignRole() + ' token=' + preparePayload.restart_token + ' delay=' + preparePayload.shutdown_delay_ms + ' host=' + preparePayload.host_id + ' name=' + displayName());
             gwCampaignEnabled(true);
             gwCampaignRestartRequestInFlight = false;
             gwCampaignRestartPending(true);

--- a/ui/main/game/galactic_war/gw_start/gw_start.html
+++ b/ui/main/game/galactic_war/gw_start/gw_start.html
@@ -102,6 +102,10 @@
                         <input type="checkbox" data-bind="checked: newGameLockCoopPlayers"/>
                         <loc>Lock number of slots</loc> <span id="coop-lock-settings" class="info_tip" data-bind="tooltip: '!LOC:Locks the maximum number of players to the number of slots in co-op.'">?</span>
                     </label>
+                    <label style="text-transform: none" id="coop-share-label">
+                        <input type="checkbox" data-bind="checked: newGameSharedByDefault"/>
+                        <loc>Share control by default</loc> <span id="coop-share-settings" class="info_tip" data-bind="tooltip: '!LOC:Turn this on to default co-op lobbies to shared armies. This is only a default setting and can be changed mid-game.'">?</span>
+                    </label>
                </div>
 
                 <div class="form-group">

--- a/ui/main/game/galactic_war/gw_start/gw_start.js
+++ b/ui/main/game/galactic_war/gw_start/gw_start.js
@@ -252,6 +252,7 @@ $(document).ready(function() {
         self.newGameHardcore = ko.observable(false);
         self.newGameCoopPlayers = ko.observable('');
         self.newGameLockCoopPlayers = ko.observable(false);
+        self.newGameSharedByDefault = ko.observable(true);
 
         self.newGameCoopPlayersSpecified = ko.computed(function() {
             var value = self.newGameCoopPlayers();
@@ -347,6 +348,7 @@ $(document).ready(function() {
             game.coopPlayers(self.normalizedNewGameCoopPlayers());
             game.coopPlayersSpecified(self.newGameCoopPlayersSpecified());
             game.lockCoopPlayers(self.newGameLockCoopPlayers());
+            game.sharedByDefault(self.newGameSharedByDefault());
 
             var useEasySystems = GW.balance.difficultyInfo[self.newGameDifficultyIndex() || 0].useEasierSystemTemplate;
             var systemTemplates = useEasySystems ? easy_system_templates : star_system_templates;
@@ -658,7 +660,8 @@ $(document).ready(function() {
                 self.newGameDifficultyIndex(),
                 self.newGameHardcore(),
                 self.newGameCoopPlayers(),
-                self.newGameLockCoopPlayers()
+                self.newGameLockCoopPlayers(),
+                self.newGameSharedByDefault()
             ];
         });
 

--- a/ui/main/game/galactic_war/shared/gw_specs.js
+++ b/ui/main/game/galactic_war/shared/gw_specs.js
@@ -267,7 +267,7 @@ define([], function()
                         value = String(spec && spec[level]);
                     }
 
-                    console.log('[GW_COOP] modSpecs skipped mod error=' + error
+                    console.log('[GW COOP] modSpecs skipped mod error=' + error
                         + ' level=' + level
                         + ' value=' + value
                         + ' mod=' + JSON.stringify(mod)

--- a/ui/main/game/galactic_war/shared/js/gw_game.js
+++ b/ui/main/game/galactic_war/shared/js/gw_game.js
@@ -43,6 +43,7 @@ define([
         self.coopPlayers = ko.observable(2);
         self.coopPlayersSpecified = ko.observable(false);
         self.lockCoopPlayers = ko.observable(false);
+        self.sharedByDefault = ko.observable(true);
 
         self.serverModIdentifiers = ko.observableArray([]);
 
@@ -113,6 +114,7 @@ define([
             self.coopPlayers(_.isFinite(coopPlayers) && coopPlayers > 0 ? Math.floor(coopPlayers) : 1);
             self.coopPlayersSpecified(!!config.coopPlayersSpecified);
             self.lockCoopPlayers(!!config.lockCoopPlayers);
+            self.sharedByDefault(_.has(config, 'sharedByDefault') ? !!config.sharedByDefault : true);
 
             self.serverModIdentifiers(config.serverModIdentifiers || []);
 
@@ -158,6 +160,7 @@ define([
                 coopPlayers: self.coopPlayers(),
                 coopPlayersSpecified: self.coopPlayersSpecified(),
                 lockCoopPlayers: self.lockCoopPlayers(),
+                sharedByDefault: self.sharedByDefault(),
                 serverModIdentifiers: self.serverModIdentifiers()
             };
 

--- a/ui/main/game/galactic_war/shared/js/gw_specs.js
+++ b/ui/main/game/galactic_war/shared/js/gw_specs.js
@@ -267,7 +267,7 @@ define([], function()
                         value = String(spec && spec[level]);
                     }
 
-                    console.log('[GW_COOP] modSpecs skipped mod error=' + error
+                    console.log('[GW COOP] modSpecs skipped mod error=' + error
                         + ' level=' + level
                         + ' value=' + value
                         + ' mod=' + JSON.stringify(mod)

--- a/ui/main/game/game_over/game_over.js
+++ b/ui/main/game/game_over/game_over.js
@@ -93,7 +93,7 @@ $(document).ready(function () {
         });
 
         self.filterMenuButtonsForRole = function(menu) {
-            console.log("[GW_COOP] filterMenuButtonsForRole function called with role: " + self.gwCampaignRole() + " and menu: ", menu);
+            console.log("[GW COOP] filterMenuButtonsForRole function called with role: " + self.gwCampaignRole() + " and menu: ", menu);
             if (!self.isGwCampaignViewer())
                 return menu;
 

--- a/ui/main/game/gw_campaign_loading/gw_campaign_loading.js
+++ b/ui/main/game/gw_campaign_loading/gw_campaign_loading.js
@@ -73,7 +73,7 @@ requireGW([
                 self.navigating = true;
                 self.clearSnapshotRetry();
                 self.pageSubTitle(loc('!LOC:Entering co-op campaign...'));
-                console.log('[GW_COOP] campaign_loading complete reason=' + reason + ' target=' + gwCampaignTarget);
+                console.log('[GW COOP] campaign_loading complete reason=' + reason + ' target=' + gwCampaignTarget);
                 window.location.href = gwCampaignTarget;
             };
 
@@ -98,7 +98,7 @@ requireGW([
 
                 self.snapshotRequestedAt = now;
                 self.pageSubTitle(loc('!LOC:Receiving co-op campaign data...'));
-                console.log('[GW_COOP] campaign_loading request snapshot reason=' + reason);
+                console.log('[GW COOP] campaign_loading request snapshot reason=' + reason);
                 self.sendMessage('request_gw_campaign_snapshot', {}, function(success, response) {
                     if (success && response && response.has_snapshot === false)
                         self.pageSubTitle(loc('!LOC:Waiting for host campaign data...'));
@@ -193,7 +193,7 @@ requireGW([
                         self.markAuthoritativeGameReady(hydratedGame.id);
                         self.finishLoading('snapshot_seq_' + (payload.seq || 0));
                     }, function(err) {
-                        console.error('[GW_COOP] campaign_loading failed to save snapshot', err);
+                        console.error('[GW COOP] campaign_loading failed to save snapshot', err);
                         self.pageSubTitle(loc('!LOC:Failed to load co-op campaign data'));
                     });
                 });
@@ -235,7 +235,7 @@ requireGW([
         };
 
         handlers.gw_campaign_snapshot = function(payload) {
-            console.log('[GW_COOP] campaign_loading snapshot recv seq=' + (payload && payload.seq) + ' reason=' + (payload && payload.reason));
+            console.log('[GW COOP] campaign_loading snapshot recv seq=' + (payload && payload.seq) + ' reason=' + (payload && payload.reason));
             model.saveSnapshotAndEnter(payload);
         };
 

--- a/ui/main/game/gw_campaign_restart_loading/gw_campaign_restart_loading.js
+++ b/ui/main/game/gw_campaign_restart_loading/gw_campaign_restart_loading.js
@@ -74,7 +74,7 @@ $(document).ready(function () {
             var hostStartDelay = Math.max(0, remainingShutdownDelay + HOST_START_MARGIN_MS);
             var viewerReconnectDelay = Math.max(0, remainingShutdownDelay + VIEWER_RECONNECT_MARGIN_MS);
 
-            console.log('[GW_COOP] restart_loading begin role=' + role + ' shutdownDelay=' + shutdownDelay + ' remainingShutdown=' + remainingShutdownDelay + ' hostStartDelay=' + hostStartDelay + ' viewerDelay=' + viewerReconnectDelay + ' token=' + restartToken);
+            console.log('[GW COOP] restart_loading begin role=' + role + ' shutdownDelay=' + shutdownDelay + ' remainingShutdown=' + remainingShutdownDelay + ' hostStartDelay=' + hostStartDelay + ' viewerDelay=' + viewerReconnectDelay + ' token=' + restartToken);
 
             self.connectionAttempts(30);
             self.connectionRetryDelaySeconds(2);
@@ -106,7 +106,7 @@ $(document).ready(function () {
                     else
                         self.serverType('uber');
 
-                    console.log('[GW_COOP] restart_loading host starting gw_campaign local=' + !!params.local + ' content=' + params.content);
+                    console.log('[GW COOP] restart_loading host starting gw_campaign local=' + !!params.local + ' content=' + params.content);
 
                     window.location.href = 'coui://ui/main/game/connect_to_game/connect_to_game.html?' + $.param(params);
                 }, hostStartDelay);
@@ -127,7 +127,7 @@ $(document).ready(function () {
                     content: content
                 }));
 
-                console.log('[GW_COOP] restart_loading viewer entering reconnect flow');
+                console.log('[GW COOP] restart_loading viewer entering reconnect flow');
 
                 window.location.href = 'coui://ui/main/game/connect_to_game/connect_to_game.html?content=' + encodeURIComponent(content);
             }, viewerReconnectDelay);

--- a/ui/main/game/gw_reconnect_loading/gw_reconnect_loading.js
+++ b/ui/main/game/gw_reconnect_loading/gw_reconnect_loading.js
@@ -187,7 +187,7 @@ $(document).ready(function () {
             return tagDone.promise();
         };
 
-        console.log('[GW_COOP] gw_reconnect_loading discovered local overlay unit tags ' + JSON.stringify(summarizeTaggedUnitLists(taggedUnitLists)));
+        console.log('[GW COOP] gw_reconnect_loading discovered local overlay unit tags ' + JSON.stringify(summarizeTaggedUnitLists(taggedUnitLists)));
 
         var gameId = ko.observable().extend({ local: 'gw_active_game' })();
         if (!gameId) {
@@ -248,7 +248,7 @@ $(document).ready(function () {
                             GW.specs.modSpecs(playerFiles, inventory.mods(), '.player');
                         } catch (e) {
                             var errorText = e && (e.stack || e.message || e.toString && e.toString());
-                            console.log('[GW_COOP] gw_reconnect_loading local overlay modSpecs failed error=' + (errorText || JSON.stringify(e))
+                            console.log('[GW COOP] gw_reconnect_loading local overlay modSpecs failed error=' + (errorText || JSON.stringify(e))
                                 + ' modCount=' + inventory.mods().length
                                 + ' playerFileCount=' + _.keys(playerFiles).length
                                 + ' mods=' + JSON.stringify(inventory.mods()));
@@ -262,7 +262,7 @@ $(document).ready(function () {
 
                     $.when.apply($, filesToProcess).then(function() {
                         var localFiles = _.assign.apply(_, [{}].concat(Array.prototype.slice.call(arguments)));
-                        console.log('[GW_COOP] gw_reconnect_loading local overlay files generated count=' + _.keys(localFiles).length);
+                        console.log('[GW COOP] gw_reconnect_loading local overlay files generated count=' + _.keys(localFiles).length);
                         done.resolve(localFiles);
                     });
                 }, function() {
@@ -292,7 +292,7 @@ $(document).ready(function () {
 
         buildLocalClientOverlayFiles(msg).always(function(localOverlayFiles) {
             var mergedFiles = _.assign({}, msg, _.isObject(localOverlayFiles) ? localOverlayFiles : {});
-            console.log('[GW_COOP] gw_reconnect_loading merging local overlay files, total count=' + _.keys(mergedFiles).length);
+            console.log('[GW COOP] gw_reconnect_loading merging local overlay files, total count=' + _.keys(mergedFiles).length);
 
             var cookedFiles = _.mapValues(mergedFiles, function(value) {
                 if (typeof value !== 'string')

--- a/ui/main/game/live_game/live_game_menu.js
+++ b/ui/main/game/live_game/live_game_menu.js
@@ -65,8 +65,8 @@ $(document).ready(function () {
     model = new MenuViewModel();
 
     handlers.state = function (payload) {
-        console.log('[GW_COOP] live game menu state handler got payload', payload);
-        console.log('[GW_COOP] live game menu current gw_campaign_role=' + model.gwCampaignRole());
+        console.log('[GW COOP] live game menu state handler got payload', payload);
+        console.log('[GW COOP] live game menu current gw_campaign_role=' + model.gwCampaignRole());
         model.refreshRoleAndState(payload);
     };
 


### PR DESCRIPTION
Added unshared play to coop galactic war. There is now a button which players can press to toggle shared armies on or off. Additionally, there is a non-GWO compatible (as of now) checkbox to set the default shared/unshared behavior for a new galactic war. Unshared co-op clients are treated similar to subcommanders in the sense that they all die if the host dies, whereas the host is fine if they die.

Also fixed a minor pesky issue where I had both [GW_COOP] and [GW COOP] debug prefixes.