### PR TITLE
fixed devmode cheat - win button

### DIFF
--- a/ui/main/game/galactic_war/gw_play/gw_play.html
+++ b/ui/main/game/galactic_war/gw_play/gw_play.html
@@ -423,7 +423,7 @@
                 </div>
 
                 <div data-bind="visible: fighting">
-                    <div class="btn_hero" data-bind="click: function() { win(-1);}, click_sound: 'default', rollover_sound: 'default'">
+                    <div class="btn_hero" data-bind="click: function() { win(-1); }, click_sound: 'default', rollover_sound: 'default'">
                         <div class="btn_label">
                             Win
                         </div>

--- a/ui/main/game/galactic_war/gw_play/gw_play.html
+++ b/ui/main/game/galactic_war/gw_play/gw_play.html
@@ -423,7 +423,7 @@
                 </div>
 
                 <div data-bind="visible: fighting">
-                    <div class="btn_hero" data-bind="click: function() { win(-1); }, click_sound: 'default', rollover_sound: 'default'">
+                    <div class="btn_hero" data-bind="click: function() { win(-1);}, click_sound: 'default', rollover_sound: 'default'">
                         <div class="btn_label">
                             Win
                         </div>

--- a/ui/main/game/galactic_war/gw_play/gw_play.js
+++ b/ui/main/game/galactic_war/gw_play/gw_play.js
@@ -3331,6 +3331,12 @@ requireGW([
                 });
             }
 
+            // Used only for the cheat menu available with the --devmode launch parameters
+            if (action.type === 'fight_begin') {
+                game.turnState(GW.Game.turnStates.fight);
+                return finish();
+            }
+
             self.gwCampaignReplayingAction = false;
             result.reject('Unknown or invalid campaign action type=' + action.type);
             return result.promise();
@@ -4580,6 +4586,7 @@ requireGW([
             api.audio.playSound('/VO/Computer/gw/board_tech_dismissed');
         };
 
+
         self.win = function(selected_card_index) {
             if (self.canUseCoopTechChoice() && self.isCampaignViewer() && !self.gwCampaignReplayingAction) {
                 var tech_card = self.currentSystemCardList()[selected_card_index];
@@ -4745,6 +4752,9 @@ requireGW([
             if (self.isCampaignViewer())
                 return;
 
+            if (self.gwCampaignReplayingAction) 
+                return;
+
             if (self.gwCampaignHasEmptySlots()) {
                 console.log('[GW COOP] fight blocked while campaign has empty slots');
                 return;
@@ -4761,7 +4771,10 @@ requireGW([
             if (self.launchingFight() || (!self.fighting() && !game.fight())) {
                 return;
             }
+            
             var save = GW.manifest.saveGame(game);
+ 
+            self.sendCampaignAction('fight_begin')
 
             if (cheat)
                 return;

--- a/ui/main/game/galactic_war/gw_play/gw_play.js
+++ b/ui/main/game/galactic_war/gw_play/gw_play.js
@@ -4771,7 +4771,6 @@ requireGW([
                 return;
             }
             var save = GW.manifest.saveGame(game);
- 
             self.sendCampaignAction('fight_begin')
 
             if (cheat)

--- a/ui/main/game/galactic_war/gw_play/gw_play.js
+++ b/ui/main/game/galactic_war/gw_play/gw_play.js
@@ -4586,7 +4586,6 @@ requireGW([
             api.audio.playSound('/VO/Computer/gw/board_tech_dismissed');
         };
 
-
         self.win = function(selected_card_index) {
             if (self.canUseCoopTechChoice() && self.isCampaignViewer() && !self.gwCampaignReplayingAction) {
                 var tech_card = self.currentSystemCardList()[selected_card_index];
@@ -4771,7 +4770,6 @@ requireGW([
             if (self.launchingFight() || (!self.fighting() && !game.fight())) {
                 return;
             }
-            
             var save = GW.manifest.saveGame(game);
  
             self.sendCampaignAction('fight_begin')


### PR DESCRIPTION
Bug fix:
Using the devmode menu (available through the --devmode launch parameter) to cheat and win games in galactic war Co-op now properly syncs with clients.